### PR TITLE
fix error reporting on async responses

### DIFF
--- a/src/dccboxed-config.ts
+++ b/src/dccboxed-config.ts
@@ -242,8 +242,13 @@ export = function (RED: NodeAPI) {
             )
           })
           .catch((e) => {
-            RED.log.debug(`request failed duis validation`)
-            this.events.emit('error', e)
+            RED.log.warn('async response failed duis validation')
+            try {
+              /* if no listeners, error emitter throws error */
+              this.events.emit('error', e)
+            } catch {
+              RED.log.warn(e)
+            }
             res.status(400)
             res.send()
           })

--- a/src/dccboxed-receive.ts
+++ b/src/dccboxed-receive.ts
@@ -245,6 +245,8 @@ export = function (RED: NodeAPI) {
     }
 
     this.server.events.on('duis', NewDuis)
+    this.server.events.on('error', (e) => this.warn(e))
+
     this.on('close', () => {
       this.server.events.removeListener('duis', NewDuis)
     })


### PR DESCRIPTION
When an error occurs during DUIS validation of an asynchronous response, it is not correctly handled and marked as `Uncaught Exception` such as below:

```
28 Sep 13:58:12 - [red] Uncaught Exception:
28 Sep 13:58:12 - [error] Error: missing credentials
[I] passed xsd validation
[W] cert file not provided, looking up serial number
[E] could not locate certificate for: 50669612984035780967362471400449834504
    at ChildProcess.<anonymous> (/home/xxx/dccboxed-nodered-nodes/node_modules/@smartdcc/duis-sign-wrap/dist/tool.
js:74:31)
    at ChildProcess.emit (node:events:513:28)
    at maybeClose (node:internal/child_process:1091:16)
    at ChildProcess._handle.onexit (node:internal/child_process:302:5)
```

Patch fixes this and ensure these are logged as warnings in the UI.