### PR TITLE
Fix multiple configs with same path

### DIFF
--- a/src/dccboxed-config/dccboxed-config.html
+++ b/src/dccboxed-config/dccboxed-config.html
@@ -38,9 +38,9 @@
   </div>
   <div class="form-row form-tips">
     The <i>Response</i> is a URI located on this <i>node-red</i> server which
-    will receive the DUIS responses from DCC Boxed. It must begin with
-    <code>/smartdcc/</code> and also DCC Boxed be configured to send responses
-    to it.
+    will receive the DUIS responses from DCC Boxed. It must be unique, begin
+    with <code>/smartdcc/</code> and also DCC Boxed be configured to send
+    responses to it.
   </div>
   <div class="form-row">
     <label for="node-config-input-localKeyStore"


### PR DESCRIPTION
Add validation to ensure the DUIS response path in the `dccboxed-config` node is unique. Includes the following:

* highlighted red when editing config
* error message when during deployment