### PR TITLE
Dccboxed 1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smartdcc/dccboxed-nodered-nodes",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@smartdcc/dccboxed-nodered-nodes",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@smartdcc/dccboxed-keystore": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@smartdcc/dccboxed-keystore": "^0.1.1",
         "@smartdcc/duis-parser": "^0.4.0",
-        "@smartdcc/duis-sign-wrap": "^0.1.0",
+        "@smartdcc/duis-sign-wrap": "^0.1.1",
         "@smartdcc/duis-templates": "^0.2.0",
-        "@smartdcc/gbcs-parser": "^0.2.0",
+        "@smartdcc/gbcs-parser": "^0.2.2",
         "@ungap/structured-clone": "^1.0.1",
         "body-parser": "^1.20.0",
         "content-type": "^1.0.4",
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@smartdcc/duis-sign-wrap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@smartdcc/duis-sign-wrap/-/duis-sign-wrap-0.1.0.tgz",
-      "integrity": "sha512-gZ2MWm8HfofWogxlNGVUk85Pwb1wmEW8FkvWlJsXww+P1K32OgzsqwhwlURRmGL23YR2pUuKZHkpz1E5mKFoMQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@smartdcc/duis-sign-wrap/-/duis-sign-wrap-0.1.1.tgz",
+      "integrity": "sha512-o4fVndHQLHgZsb6TgHdKqRiVvBcmkVsn2BXMoTLYNyt9UFJUE/HsGphpvnMdmrbgpTt9CUaexDqdd2ysKZbAYg==",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -346,9 +346,9 @@
       }
     },
     "node_modules/@smartdcc/gbcs-parser": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@smartdcc/gbcs-parser/-/gbcs-parser-0.2.1.tgz",
-      "integrity": "sha512-RZWhW4NXeDFONqcIVeh+vGXjopK9f9wBBzqWJ6gmlMrKgWA/pHwP0/3LgP5LEsger+OHbnHepVkl3L1xgCiDsw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@smartdcc/gbcs-parser/-/gbcs-parser-0.2.2.tgz",
+      "integrity": "sha512-y+K9trJWmT7Osrb0T77ss1zspBi5nHoAFL9mDViE64+/39Nt94ysFCtym+twwIST8j+EEk8uRUIjV0WWmivquQ==",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -5192,9 +5192,9 @@
       }
     },
     "@smartdcc/duis-sign-wrap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@smartdcc/duis-sign-wrap/-/duis-sign-wrap-0.1.0.tgz",
-      "integrity": "sha512-gZ2MWm8HfofWogxlNGVUk85Pwb1wmEW8FkvWlJsXww+P1K32OgzsqwhwlURRmGL23YR2pUuKZHkpz1E5mKFoMQ=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@smartdcc/duis-sign-wrap/-/duis-sign-wrap-0.1.1.tgz",
+      "integrity": "sha512-o4fVndHQLHgZsb6TgHdKqRiVvBcmkVsn2BXMoTLYNyt9UFJUE/HsGphpvnMdmrbgpTt9CUaexDqdd2ysKZbAYg=="
     },
     "@smartdcc/duis-templates": {
       "version": "0.2.0",
@@ -5245,9 +5245,9 @@
       }
     },
     "@smartdcc/gbcs-parser": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@smartdcc/gbcs-parser/-/gbcs-parser-0.2.1.tgz",
-      "integrity": "sha512-RZWhW4NXeDFONqcIVeh+vGXjopK9f9wBBzqWJ6gmlMrKgWA/pHwP0/3LgP5LEsger+OHbnHepVkl3L1xgCiDsw=="
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@smartdcc/gbcs-parser/-/gbcs-parser-0.2.2.tgz",
+      "integrity": "sha512-y+K9trJWmT7Osrb0T77ss1zspBi5nHoAFL9mDViE64+/39Nt94ysFCtym+twwIST8j+EEk8uRUIjV0WWmivquQ=="
     },
     "@szmarczak/http-timer": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartdcc/dccboxed-nodered-nodes",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Collection of nodes for NodeRED to facilitate interfacing with DCC Boxed",
   "type": "commonjs",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
   "dependencies": {
     "@smartdcc/dccboxed-keystore": "^0.1.1",
     "@smartdcc/duis-parser": "^0.4.0",
-    "@smartdcc/duis-sign-wrap": "^0.1.0",
+    "@smartdcc/duis-sign-wrap": "^0.1.1",
     "@smartdcc/duis-templates": "^0.2.0",
-    "@smartdcc/gbcs-parser": "^0.2.0",
+    "@smartdcc/gbcs-parser": "^0.2.2",
     "@ungap/structured-clone": "^1.0.1",
     "body-parser": "^1.20.0",
     "content-type": "^1.0.4",


### PR DESCRIPTION
Update dependencies for DCC Boxed 1.4.1 alignment. Changes are backwards compatible with 1.4.0.