### PR TITLE
Increase timeout on autocomplete

### DIFF
--- a/src/duis-template/duis-template.editor.ts
+++ b/src/duis-template/duis-template.editor.ts
@@ -274,7 +274,7 @@ RED.nodes.registerType<Properties & EditorNodeProperties>('duis-template', {
                 url: 'smartdcc/duis-template/search',
                 dataType: 'json',
                 data: { q: value },
-                timeout: 100,
+                timeout: 250,
                 success(data: TemplateDTO[]) {
                   if (!Array.isArray(data)) {
                     RED.notify('failed to search templates', {


### PR DESCRIPTION
Sometimes when accessing NodeRED remotely the 100ms timeout on autocomplete was too short. So increased it to improve search.