### PR TITLE
Recolour low level nodes

### DIFF
--- a/src/dccboxed-receive/dccboxed-receive.editor.ts
+++ b/src/dccboxed-receive/dccboxed-receive.editor.ts
@@ -19,7 +19,7 @@
 
 import type { EditorRED, EditorNodeProperties } from 'node-red'
 import type { Properties } from '../dccboxed-receive.properties'
-import { settings } from '../editor-global-settings'
+import { settingsHigh as settings } from '../editor-global-settings'
 
 declare const RED: EditorRED
 declare const $: JQueryStatic

--- a/src/dccboxed-send/dccboxed-send.editor.ts
+++ b/src/dccboxed-send/dccboxed-send.editor.ts
@@ -19,7 +19,7 @@
 
 import type { EditorRED, EditorNodeProperties } from 'node-red'
 import type { Properties } from '../dccboxed-send.properties'
-import { settings } from '../editor-global-settings'
+import { settingsHigh as settings } from '../editor-global-settings'
 
 declare const RED: EditorRED
 declare const $: JQueryStatic

--- a/src/duis-construct/duis-construct.editor.ts
+++ b/src/duis-construct/duis-construct.editor.ts
@@ -19,7 +19,7 @@
 
 import type { EditorRED, EditorNodeProperties } from 'node-red'
 import { Properties } from '../duis-construct.properties'
-import { settings } from '../editor-global-settings'
+import { settingsLow as settings } from '../editor-global-settings'
 
 declare const RED: EditorRED
 

--- a/src/duis-parser/duis-parser.editor.ts
+++ b/src/duis-parser/duis-parser.editor.ts
@@ -19,7 +19,7 @@
 
 import type { EditorRED, EditorNodeProperties } from 'node-red'
 import type { Properties } from '../duis-parser.properties'
-import { settings } from '../editor-global-settings'
+import { settingsLow as settings } from '../editor-global-settings'
 
 declare const RED: EditorRED
 declare const $: JQueryStatic

--- a/src/duis-sign/duis-sign.editor.ts
+++ b/src/duis-sign/duis-sign.editor.ts
@@ -23,7 +23,7 @@ import type {
   EditorNodeInstance,
 } from 'node-red'
 import { Properties } from '../duis-sign.properties'
-import { settings } from '../editor-global-settings'
+import { settingsLow as settings } from '../editor-global-settings'
 
 declare const RED: EditorRED
 

--- a/src/duis-template/duis-template.editor.ts
+++ b/src/duis-template/duis-template.editor.ts
@@ -29,7 +29,7 @@ import type {
 } from '../duis-template.properties'
 import {
   euiValidator,
-  settings,
+  settingsHigh as settings,
   typedInputEUI,
 } from '../editor-global-settings'
 

--- a/src/editor-global-settings.ts
+++ b/src/editor-global-settings.ts
@@ -22,9 +22,14 @@ import { EditorWidgetTypedInputTypeDefinition } from 'node-red'
 /**
  * default values to be used for nodes in editor
  */
-export const settings = {
+export const settingsHigh = {
   color: '#f0b3ff',
   category: 'smartdcc',
+}
+
+export const settingsLow = {
+  color: '#bbb3ff',
+  category: 'smartdcc lowlevel',
 }
 
 /**

--- a/src/gbcs-parser/gbcs-parser.editor.ts
+++ b/src/gbcs-parser/gbcs-parser.editor.ts
@@ -19,7 +19,7 @@
 
 import type { EditorRED, EditorNodeProperties } from 'node-red'
 import type { KeyDefinition, Properties } from '../gbcs-parser.properties'
-import { settings } from '../editor-global-settings'
+import { settingsLow as settings } from '../editor-global-settings'
 
 import './gbcs-parser.css'
 

--- a/src/gbcs-signer/gbcs-signer.editor.ts
+++ b/src/gbcs-signer/gbcs-signer.editor.ts
@@ -21,7 +21,7 @@ import type { EditorRED, EditorNodeProperties } from 'node-red'
 import type { KeyDefinition, Properties } from '../gbcs-signer.properties'
 import {
   euiValidator,
-  settings,
+  settingsLow as settings,
   typedInputEUI,
 } from '../editor-global-settings'
 

--- a/src/gbcs-utrn/gbcs-utrn.editor.ts
+++ b/src/gbcs-utrn/gbcs-utrn.editor.ts
@@ -25,7 +25,7 @@ import type {
 import type { KeyDefinition, Properties } from '../gbcs-utrn.properties'
 import {
   euiValidator,
-  settings,
+  settingsHigh as settings,
   typedInputEUI,
 } from '../editor-global-settings'
 


### PR DESCRIPTION
Recolour nodes which provide low level and rarely used features such as:

- DUIS construct
- DUIS parse
- DUIS sign
- GBCS parse
- GBCS sign

This is to reduce confusion when starting out.