### PR TITLE
UI notification for device alerts

### DIFF
--- a/src/dccboxed-config.properties.ts
+++ b/src/dccboxed-config.properties.ts
@@ -71,4 +71,16 @@ export interface ConfigNode extends Node {
   ) => Promise<SimplifiedDuisOutputResponse>
   logger: (msg: string) => void | Promise<void>
   logfile?: FileHandle
+  publish: (nodeId: string, body: WSMessageBody) => void
 }
+
+export interface WSMessageNotification {
+  kind: 'notification'
+  message: string
+  type?: 'compact' | 'success' | 'warning' | 'error'
+  timeout?: number
+}
+
+export type WSMessageBody = WSMessageNotification
+
+export type WSMessageDTO = { id: string; sourceNode: string } & WSMessageBody

--- a/src/dccboxed-config.ts
+++ b/src/dccboxed-config.ts
@@ -24,6 +24,7 @@ import type {
   DspEndpoint,
   MessageStore,
   Properties,
+  WSMessageDTO,
 } from './dccboxed-config.properties'
 
 import * as bodyParser from 'body-parser'
@@ -285,6 +286,15 @@ export = function (RED: NodeAPI) {
         this.logfile.close()
       }
     })
+
+    this.publish = (nodeId, body) => {
+      const payload: WSMessageDTO = { id: this.id, sourceNode: nodeId, ...body }
+      RED.comms.publish(
+        `smartdcc/config/${this.id}/${body.kind}`,
+        payload,
+        false
+      )
+    }
   }
   RED.nodes.registerType('dccboxed-config', ConfigConstruct)
 }

--- a/src/dccboxed-receive.properties.ts
+++ b/src/dccboxed-receive.properties.ts
@@ -31,6 +31,7 @@ export interface Properties {
   outputDeviceAlertsFilterType: string
   outputDCCAlertsFilterType: string
   outputs: number
+  notifyDeviceAlerts: boolean
 }
 
 import type { Node, NodeMessage } from 'node-red'
@@ -50,4 +51,5 @@ export interface ReceiveNode extends Node {
         }
       | { type: 'none' }
   ): void
+  notifyDeviceAlerts: boolean
 }

--- a/src/dccboxed-receive/dccboxed-receive.editor.ts
+++ b/src/dccboxed-receive/dccboxed-receive.editor.ts
@@ -39,6 +39,7 @@ RED.nodes.registerType<Properties & EditorNodeProperties>('dccboxed-receive', {
     outputDeviceAlertsFilterType: { value: 'all', required: false },
     outputDCCAlertsFilterType: { value: 'all', required: false },
     outputs: { value: 4 },
+    notifyDeviceAlerts: { value: false, required: true },
   },
   inputs: 0,
   outputs: 4,

--- a/src/dccboxed-receive/dccboxed-receive.html
+++ b/src/dccboxed-receive/dccboxed-receive.html
@@ -68,6 +68,18 @@
   </div>
 
   <div class="form-row">
+    <label></label>
+    <input
+      type="checkbox"
+      id="node-input-notifyDeviceAlerts"
+      style="display: inline-block; width: auto; vertical-align: top;"
+    />
+    <label for="node-input-notifyDeviceAlerts" style="width: 70%;"
+      >UI notification on device alert</label
+    >
+  </div>
+
+  <div class="form-row">
     <label for="node-input-outputDCCAlertsFilter"
       ><i class="fa fa-sign-in"></i> DCC Alert</label
     >


### PR DESCRIPTION
Add notification for device alerts within the user interface. Can be configured from the `dccboxed-receive` node.