### PR TITLE
fix: gh action import gbcs-utrn

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -103,6 +103,8 @@ jobs:
       run: node -e 'require("./dist/gbcs-parser")'
     - name: Import gbcs-signer.js
       run: node -e 'require("./dist/gbcs-signer")'
+    - name: Import gbcs-utrn.js
+      run: node -e 'require("./dist/gbcs-utrn")'
 
   test:
     if: false # disable as currently no test cases


### PR DESCRIPTION
Build action was not validating the `gbcs-utrn` block is built.