### PR TITLE
bump gbcs-parser to 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@smartdcc/duis-parser": "^0.6.0",
         "@smartdcc/duis-sign-wrap": "^0.1.1",
         "@smartdcc/duis-templates": "^0.5.0",
-        "@smartdcc/gbcs-parser": "^0.3.0",
+        "@smartdcc/gbcs-parser": "^0.3.1",
         "@ungap/structured-clone": "^1.0.1",
         "body-parser": "^1.20.0",
         "content-type": "^1.0.4",
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/@smartdcc/gbcs-parser": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@smartdcc/gbcs-parser/-/gbcs-parser-0.3.0.tgz",
-      "integrity": "sha512-R8bdrMOW9luaQf2jMJVojrhtzsJ0//+fAI1uPYaPPuvMIIT9fKdvw+nJ3gpwtI5gzOFf7FvgeQQXBnzForJC7Q==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@smartdcc/gbcs-parser/-/gbcs-parser-0.3.1.tgz",
+      "integrity": "sha512-kEr31UmAQlDat6NncWJAdYipnYK7Y71jx5pzpeJclxftM3u7hRO20/CHvnhbz3ltUL+ekkjIX6Nmg0NPix07pg==",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -5459,9 +5459,9 @@
       }
     },
     "@smartdcc/gbcs-parser": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@smartdcc/gbcs-parser/-/gbcs-parser-0.3.0.tgz",
-      "integrity": "sha512-R8bdrMOW9luaQf2jMJVojrhtzsJ0//+fAI1uPYaPPuvMIIT9fKdvw+nJ3gpwtI5gzOFf7FvgeQQXBnzForJC7Q=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@smartdcc/gbcs-parser/-/gbcs-parser-0.3.1.tgz",
+      "integrity": "sha512-kEr31UmAQlDat6NncWJAdYipnYK7Y71jx5pzpeJclxftM3u7hRO20/CHvnhbz3ltUL+ekkjIX6Nmg0NPix07pg=="
     },
     "@szmarczak/http-timer": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@smartdcc/duis-parser": "^0.6.0",
     "@smartdcc/duis-sign-wrap": "^0.1.1",
     "@smartdcc/duis-templates": "^0.5.0",
-    "@smartdcc/gbcs-parser": "^0.3.0",
+    "@smartdcc/gbcs-parser": "^0.3.1",
     "@ungap/structured-clone": "^1.0.1",
     "body-parser": "^1.20.0",
     "content-type": "^1.0.4",


### PR DESCRIPTION
update dependency @smartdcc/gbcs-parser to 0.3.1 which fixes an issue converting 32bit two's complements into base 10 numbers.