### PR TITLE
Support global/flow parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,14 @@
         "@ungap/structured-clone": "^1.0.1",
         "body-parser": "^1.20.0",
         "content-type": "^1.0.4",
-        "got": "^11.8.5"
+        "got": "^11.8.5",
+        "mustache": "^4.2.0"
       },
       "devDependencies": {
         "@tsconfig/node16": "^16.1.0",
         "@types/content-type": "^1.1.5",
         "@types/jquery-mask-plugin": "^1.14.4",
+        "@types/mustache": "^4.2.5",
         "@types/node-red": "^1.2.1",
         "@types/ungap__structured-clone": "^1.2.0",
         "@typescript-eslint/eslint-plugin": "^6.1.0",
@@ -573,6 +575,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "node_modules/@types/mustache": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.2.5.tgz",
+      "integrity": "sha512-PLwiVvTBg59tGFL/8VpcGvqOu3L4OuveNvPi0EYbWchRdEVP++yRUXJPFl+CApKEq13017/4Nf7aQ5lTtHUNsA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -3512,6 +3520,14 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -5635,6 +5651,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "@types/mustache": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.2.5.tgz",
+      "integrity": "sha512-PLwiVvTBg59tGFL/8VpcGvqOu3L4OuveNvPi0EYbWchRdEVP++yRUXJPFl+CApKEq13017/4Nf7aQ5lTtHUNsA==",
       "dev": true
     },
     "@types/node": {
@@ -7803,6 +7825,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
     },
     "nanoid": {
       "version": "3.3.7",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tsconfig/node16": "^16.1.0",
     "@types/content-type": "^1.1.5",
     "@types/jquery-mask-plugin": "^1.14.4",
+    "@types/mustache": "^4.2.5",
     "@types/node-red": "^1.2.1",
     "@types/ungap__structured-clone": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^6.1.0",
@@ -59,7 +60,8 @@
     "@ungap/structured-clone": "^1.0.1",
     "body-parser": "^1.20.0",
     "content-type": "^1.0.4",
-    "got": "^11.8.5"
+    "got": "^11.8.5",
+    "mustache": "^4.2.0"
   },
   "node-red": {
     "nodes": {

--- a/src/duis-template.properties.ts
+++ b/src/duis-template.properties.ts
@@ -33,9 +33,9 @@ export interface Properties {
   output?: string
   enableInject: boolean
   originatorEUI?: string
-  originatorEUI_type: 'default' | 'msg' | 'eui'
+  originatorEUI_type: 'default' | 'msg' | 'flow' | 'global' | 'eui'
   targetEUI?: string
-  targetEUI_type: 'default' | 'msg' | 'eui'
+  targetEUI_type: 'default' | 'msg' | 'flow' | 'global' | 'eui'
   deafultName?: string
 }
 
@@ -44,8 +44,8 @@ export interface Node extends RedNode {
   templateBody?: XMLData
   minimal: boolean
   output: (msg: NodeMessage, value: unknown) => void
-  originatorEUI: (msg: NodeMessage) => string | undefined
-  targetEUI: (msg: NodeMessage) => string | undefined
+  originatorEUI: (msg: NodeMessage) => Promise<string | undefined>
+  targetEUI: (msg: NodeMessage) => Promise<string | undefined>
 }
 
 export interface TemplateDTO {

--- a/src/duis-template/duis-template.editor.ts
+++ b/src/duis-template/duis-template.editor.ts
@@ -282,6 +282,8 @@ RED.nodes.registerType<ENT>('duis-template', {
         default: 'default',
         types: [
           'msg',
+          'flow',
+          'global',
           typedInputEUI,
           {
             value: 'default',

--- a/src/editor-global-settings.ts
+++ b/src/editor-global-settings.ts
@@ -43,12 +43,16 @@ const euiRegex = /^([0-9a-fA-F]{2}([- ](?!$))?){8}$/
  * @param selector looks up the type of a typeInput
  * @returns
  */
-export function euiValidator<T>(selector: (this: T) => true | 'msg' | 'eui') {
+export function euiValidator<T>(
+  selector: (this: T) => true | 'msg' | 'flow' | 'global' | 'eui',
+) {
   return function (this: T, val: string): boolean {
     switch (selector.call(this)) {
       case true:
         return true
       case 'msg':
+      case 'flow':
+      case 'global':
         return val.length > 0
       case 'eui':
         return val.match(euiRegex) !== null

--- a/src/gbcs-utrn.properties.ts
+++ b/src/gbcs-utrn.properties.ts
@@ -28,9 +28,9 @@ export interface Properties extends GBCSNodeProperties {
   outputUtrn: string
   outputCounter: string
   signerEUI: string
-  signerEUI_type: 'msg' | 'eui'
+  signerEUI_type: 'msg' | 'flow' | 'global' | 'eui'
   deviceEUI: string
-  deviceEUI_type: 'msg' | 'eui'
+  deviceEUI_type: 'msg' | 'flow' | 'global' | 'eui'
   counter: string
   counter_type: 'msg' | 'num' | 'epoch'
   value: string
@@ -43,8 +43,8 @@ export interface Properties extends GBCSNodeProperties {
 export interface Node extends GbcsNode {
   outputUtrn: (msg: NodeMessage, value: unknown) => void
   outputCounter: (msg: NodeMessage, value: unknown) => void
-  signerEUI: (msg: NodeMessage) => unknown
-  deviceEUI: (msg: NodeMessage) => unknown
+  signerEUI: (msg: NodeMessage) => Promise<string | undefined>
+  deviceEUI: (msg: NodeMessage) => Promise<string | undefined>
   counter: (msg: NodeMessage) => unknown
   value: (msg: NodeMessage) => unknown
   class: (msg: NodeMessage) => unknown

--- a/src/gbcs-utrn/gbcs-utrn.editor.ts
+++ b/src/gbcs-utrn/gbcs-utrn.editor.ts
@@ -188,12 +188,12 @@ RED.nodes.registerType<Properties & EditorNodeProperties>('gbcs-utrn', {
     })
     $('#node-input-signerEUI').typedInput({
       default: 'eui',
-      types: ['msg', typedInputEUI],
+      types: ['msg', 'flow', 'global', typedInputEUI],
       typeField: $('#node-input-signerEUI_type'),
     })
     $('#node-input-deviceEUI').typedInput({
       default: 'eui',
-      types: ['msg', typedInputEUI],
+      types: ['msg', 'flow', 'global', typedInputEUI],
       typeField: $('#node-input-deviceEUI_type'),
     })
     $('#node-input-counter').typedInput({

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,7 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { NodeAPI, NodeMessage } from 'node-red'
+import { Node, NodeAPI, NodeContext, NodeMessage } from 'node-red'
+import { Context, TemplateSpans, parse, render } from 'mustache'
 
 export function setMessageProperty(
   RED: NodeAPI,
@@ -37,5 +38,187 @@ export function setMessageProperty(
       msg.payload = {}
       RED.util.setMessageProperty(msg, _path, value, true)
     }
+  }
+}
+
+/*
+ * Below Mustache implementation was adapted from the Node-RED template node and
+ * updated for TypeScript.
+ *
+ * For the original and licence information see:
+ * https://github.com/node-red/node-red/blob/5b096bfd5ee1c9b2a5e624ee7e13aa16b145da8b/packages/node_modules/%40node-red/nodes/core/function/80-template.js
+ */
+
+function parseContext(key: string) {
+  const match = /^(flow|global)(\[(\w+)\])?\.(.+)/.exec(key)
+  if (match) {
+    return {
+      type: match[1] as 'flow' | 'global',
+      store: match[3] === '' ? 'default' : match[3],
+      field: match[4],
+    }
+  }
+  return undefined
+}
+
+function parseEnv(key: string) {
+  const match = /^env\.(.+)/.exec(key)
+  if (match) {
+    return match[1]
+  }
+  return undefined
+}
+
+function extractTokens(tokens: TemplateSpans, set?: Set<string>): Set<string> {
+  const _set = set ?? new Set()
+  tokens.forEach((token) => {
+    if (token[0] !== 'text') {
+      _set.add(token[1])
+      if (token.length > 4) {
+        if (Array.isArray(token[4])) {
+          extractTokens(token[4], _set)
+        } else {
+          throw new Error(`unknown token ${token}`)
+        }
+      }
+    }
+  })
+  return _set
+}
+
+export class MustacheNodeContext extends Context {
+  constructor(
+    private msg: NodeMessage,
+    private nodeContext: NodeContext,
+    parent: Context | undefined,
+    private escapeStrings: boolean,
+    private cachedContextTokens: Record<string, string>,
+  ) {
+    super(msg, parent)
+  }
+
+  public lookup(name: string) {
+    // try message first:
+    let value = super.lookup(name)
+    if (value !== undefined) {
+      if (this.escapeStrings && typeof value === 'string') {
+        value = value.replace(/\\/g, '\\\\')
+        value = value.replace(/\n/g, '\\n')
+        value = value.replace(/\t/g, '\\t')
+        value = value.replace(/\r/g, '\\r')
+        value = value.replace(/\f/g, '\\f')
+        value = value.replace(/[\b]/g, '\\b')
+      }
+      return value
+    }
+
+    // try env
+    if (parseEnv(name)) {
+      return this.cachedContextTokens[name]
+    }
+
+    // try flow/global context:
+    const context = parseContext(name)
+    if (context) {
+      const type = context.type
+      //const store = context.store
+      //const field = context.field
+      const target = this.nodeContext[type]
+      if (target) {
+        return this.cachedContextTokens[name]
+      }
+    }
+    return ''
+  }
+
+  public push(view: NodeMessage): Context {
+    return new MustacheNodeContext(
+      view,
+      this.nodeContext,
+      this,
+      false,
+      this.cachedContextTokens,
+    )
+  }
+}
+
+function isPair(o: unknown): o is [string, string] {
+  return (
+    Array.isArray(o) &&
+    o.length === 2 &&
+    typeof o[0] === 'string' &&
+    typeof o[1] === 'string'
+  )
+}
+
+export function runMustache(
+  RED: NodeAPI,
+  template: string,
+  node: Node,
+  msg: NodeMessage,
+): Promise<string>
+export function runMustache(
+  RED: NodeAPI,
+  template: object,
+  node: Node,
+  msg: NodeMessage,
+): Promise<object>
+export async function runMustache(
+  RED: NodeAPI,
+  template: string | object,
+  node: Node,
+  msg: NodeMessage,
+): Promise<string | object> {
+  const templateNormalised =
+    typeof template === 'string' ? template : JSON.stringify(template)
+
+  const resolvedTokens = Object.fromEntries(
+    (
+      await Promise.all(
+        Array.from(extractTokens(parse(templateNormalised))).map((token) => {
+          const env_name = parseEnv(token)
+          if (env_name) {
+            return Promise.resolve<[string, string]>([
+              token,
+              RED.util.evaluateNodeProperty(env_name, 'env', node, msg),
+            ])
+          }
+
+          const context = parseContext(token)
+          if (context) {
+            const type = context.type
+            const store = context.store
+            const field = context.field
+            const target = node.context()[type]
+            return new Promise<[string, string]>((resolve, reject) => {
+              target.get(field, store, (err, val) => {
+                if (err) {
+                  reject(err)
+                } else {
+                  resolve([token, val as string])
+                }
+              })
+            })
+          }
+          return Promise.resolve()
+        }),
+      )
+    ).filter(isPair),
+  )
+
+  const result = render(
+    templateNormalised,
+    new MustacheNodeContext(
+      msg,
+      node.context(),
+      undefined,
+      typeof template !== 'string',
+      resolvedTokens,
+    ),
+  )
+  if (typeof template === 'string') {
+    return result
+  } else {
+    return JSON.parse(result)
   }
 }


### PR DESCRIPTION
Add support to parameterise the `duis-template` and `gbcs-utrn` blocks with global/flow variables.

For example, a `duis-template` can now use Mustache  templates:

![image](https://github.com/SmartDCCInnovation/dccboxed-nodered-nodes/assets/527411/87f18bca-b479-4da6-b945-db68978cbbbc)
