### PR TITLE
feat: auto increment utrn counter

### DIFF
--- a/src/gbcs-utrn/gbcs-utrn.css
+++ b/src/gbcs-utrn/gbcs-utrn.css
@@ -40,3 +40,7 @@ textarea.utrn-single-input {
   min-height: 20px;
   min-width: 450px;
 }
+
+.hidden {
+  visibility: hidden;
+}

--- a/src/gbcs-utrn/gbcs-utrn.editor.ts
+++ b/src/gbcs-utrn/gbcs-utrn.editor.ts
@@ -196,20 +196,44 @@ RED.nodes.registerType<Properties & EditorNodeProperties>('gbcs-utrn', {
       types: ['msg', 'flow', 'global', typedInputEUI],
       typeField: $('#node-input-deviceEUI_type'),
     })
-    $('#node-input-counter').typedInput({
-      default: 'epoch',
-      types: [
-        'msg',
-        'num',
-        {
-          value: 'epoch',
-          hasValue: false,
-          label: 'Use Epoch as Counter',
-          icon: 'fa fa-clock-o',
-        },
-      ],
-      typeField: $('#node-input-counter_type'),
-    })
+    $('#node-input-counter')
+      .typedInput({
+        default: 'epoch',
+        types: [
+          'msg',
+          'num',
+          {
+            value: 'epoch',
+            hasValue: false,
+            label: 'Use Epoch as Counter',
+            icon: 'fa fa-clock-o',
+          },
+        ],
+        typeField: $('#node-input-counter_type'),
+      })
+      .on('change', (event, type, val) => {
+        if (type === 'num') {
+          $.ajax({
+            url: `smartdcc/gbcs-utrn/${this.id}/counter/${val}`,
+            type: 'GET',
+            success: function (resp) {
+              if (
+                typeof resp === 'object' &&
+                resp !== null &&
+                typeof resp.counter === 'string' &&
+                typeof resp.offset === 'number'
+              ) {
+                $('#node-info-effective-counter').text(
+                  `Effective counter: 0x${(BigInt(resp.counter) + BigInt(resp.offset)).toString(16)}`,
+                )
+                $('#effective-counter-row').removeClass('hidden')
+              }
+            },
+          })
+        } else {
+          $('#effective-counter-row').addClass('hidden')
+        }
+      })
     $('#node-input-value').typedInput({
       default: 'num',
       types: ['msg', 'num'],

--- a/src/gbcs-utrn/gbcs-utrn.html
+++ b/src/gbcs-utrn/gbcs-utrn.html
@@ -75,6 +75,11 @@
     <input id="node-input-counter_type" type="hidden" />
   </div>
 
+  <div id="effective-counter-row" class="form-row hidden">
+    <label for="node-info-effective-counter"></label>
+    <span id="node-info-effective-counter" style="width: 70%"></span>
+  </div>
+
   <div class="form-row">
     <label for="node-input-value"><i class="fa fa-money"></i> PTUT Value</label>
     <input id="node-input-value" type="text" style="width: 70%" />


### PR DESCRIPTION
When `gbcs-utrn` block is used with explicit number for the counter, this feature will auto increment the counter and persist the value across deployment.

The current value is now displayed below the `counter (in)` field in the UI when a number is used to enter the UTRN:

![image](https://github.com/SmartDCCInnovation/dccboxed-nodered-nodes/assets/527411/ec54f59e-e416-438f-873c-938daea91738)
 