### PR TITLE
maint: update automerge config for typescript-eslint

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -27,6 +27,7 @@ jobs:
             contains(fromJSON('[
               "@typescript-eslint/eslint-plugin",
               "@typescript-eslint/parser",
+              "typescript-eslint",
               "eslint",
               "eslint-config-prettier",
               "prettier",


### PR DESCRIPTION
After updating typescript-eslint major version package structure changed, update dependabot/automerge config to compensate.